### PR TITLE
fix problem with CVE-2021-3520

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     # https://github.com/lz4/lz4/pull/962
     - patches/0002-include-local-header-directory.patch  # [win]
+    - CVE-2021-3520.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/patches/CVE-2021-3520.patch
+++ b/recipe/patches/CVE-2021-3520.patch
@@ -1,3 +1,4 @@
+See: https://github.com/lz4/lz4/pull/972
 diff --git a/lib/lz4.c b/lib/lz4.c
 index 9f5e9bf..eac0541 100644
 --- a/lib/lz4.c

--- a/recipe/patches/CVE-2021-3520.patch
+++ b/recipe/patches/CVE-2021-3520.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/lz4.c b/lib/lz4.c
+index 9f5e9bf..eac0541 100644
+--- a/lib/lz4.c
++++ b/lib/lz4.c
+@@ -1749,7 +1749,7 @@ LZ4_decompress_generic(
+                  const size_t dictSize         /* note : = 0 if noDict */
+                  )
+ {
+-    if (src == NULL) { return -1; }
++    if ((src == NULL) || (outputSize < 0)) { return -1; }
+ 
+     {   const BYTE* ip = (const BYTE*) src;
+         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
This change should help fix the problem with https://nvd.nist.gov/vuln/detail/CVE-2021-3520