### PR TITLE
Fix CVE-2021-3520

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,11 @@ source:
   patches:
     # https://github.com/lz4/lz4/pull/962
     - patches/0002-include-local-header-directory.patch  # [win]
+    # See: https://github.com/lz4/lz4/pull/972
+    - patches/CVE-2021-3520.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -75,8 +77,9 @@ outputs:
 
 
 about:
-  home: https://www.lz4.org
+  home: https://lz4.github.io/lz4/
   license: BSD-2-Clause
+  license_family: BSD
   license_file: lib/LICENSE
   summary: Extremely Fast Compression algorithm
   description: |
@@ -86,6 +89,7 @@ about:
     derivative, called LZ4_HC, is available, trading customizable CPU time for
     compression ratio. LZ4 library is provided as open source software using a
     BSD license.
+  dev_url: https://github.com/lz4/lz4
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/CVE-2021-3520.patch
+++ b/recipe/patches/CVE-2021-3520.patch
@@ -1,0 +1,22 @@
+From 8301a21773ef61656225e264f4f06ae14462bca7 Mon Sep 17 00:00:00 2001
+From: Jasper Lievisse Adriaanse <j@jasper.la>
+Date: Fri, 26 Feb 2021 15:21:20 +0100
+Subject: [PATCH] Fix potential memory corruption with negative memmove() size
+
+---
+ lib/lz4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/lz4.c b/lib/lz4.c
+index 5f524d01d..c2f504ef3 100644
+--- a/lib/lz4.c
++++ b/lib/lz4.c
+@@ -1749,7 +1749,7 @@ LZ4_decompress_generic(
+                  const size_t dictSize         /* note : = 0 if noDict */
+                  )
+ {
+-    if (src == NULL) { return -1; }
++    if ((src == NULL) || (outputSize < 0)) { return -1; }
+ 
+     {   const BYTE* ip = (const BYTE*) src;
+         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
Category:  miniconda | subcategory:   | pkg_type:  library
Popularity:  10615811 downloads -  lz4-c  1.9.3  Extremely Fast Compression algorithm  
  license in the recipe: BSD-2-Clause
Bug Tracker: https://github.com/lz4/lz4/issues
Github releases: https://github.com/lz4/lz4/releases
License: https://github.com/lz4/lz4/blob/dev/LICENSE

The package lz4-c is mentioned inside the packages:
arrow-cpp | blosc | imagecodecs | libarchive | lz4 |  mysql | orc | svn | tiledb | vtk | zstd | 

Actions:
1. Add a file CVE-2021-3520.patch and a comment to the recipe
2. Add license_family
3. Update home and dev urls

Result:
- all-succeeded