### PR TITLE
Win arm64

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,63 +1,51 @@
-:: This rougly follow what projects' appveyor file does.
+@echo off
+setlocal EnableDelayedExpansion
 
-:: Build
-if "%ARCH%"=="32" (
-    set PLATFORM=Win32
-) else (
-    set PLATFORM=x64
+:: Build lz4 shared library using CMake (supports win-64 and win-arm64)
+mkdir %SRC_DIR%\build_shared
+cd %SRC_DIR%\build_shared
+if errorlevel 1 exit 1
+
+cmake -G Ninja ^
+    %CMAKE_ARGS% ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+    -DLZ4_BUILD_CLI=ON ^
+    -DLZ4_BUILD_LEGACY_LZ4C=OFF ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -DBUILD_STATIC_LIBS=OFF ^
+    %SRC_DIR%\build\cmake
+if errorlevel 1 exit 1
+
+cmake --build . --config Release --parallel %CPU_COUNT%
+if errorlevel 1 exit 1
+
+:: Run tests only if not cross-compiling
+if not "%CONDA_BUILD_CROSS_COMPILATION%"=="1" (
+    echo Running tests...
+    lz4 -i1b lz4.exe
+    if errorlevel 1 exit 1
+    lz4 -i1b5 lz4.exe
+    if errorlevel 1 exit 1
 )
-set CONFIGURATION=Release
-set VSPROJ_DIR=%SRC_DIR%\build\VS2017
-set BUILD_DIR=%VSPROJ_DIR%\bin\%PLATFORM%_%CONFIGURATION%
 
-msbuild.exe ^
-  -m ^
-  -p:Configuration=%CONFIGURATION% ^
-  -p:Platform=%PLATFORM% ^
-  -p:PlatformToolset=v141 ^
-  -p:WindowsTargetPlatformVersion=10.0.17763.0 ^
-  -t:Build ^
-  %VSPROJ_DIR%\lz4.sln
+:: Install shared library
+cmake --install . --config Release
 if errorlevel 1 exit 1
 
-:: Test.
-cd %BUILD_DIR%
-if errorlevel 1 exit 1
-lz4 -i1b lz4.exe
-if errorlevel 1 exit 1
-lz4 -i1b5 lz4.exe
-if errorlevel 1 exit 1
-lz4 -i1b10 lz4.exe
-if errorlevel 1 exit 1
-lz4 -i1b15 lz4.exe
+:: Also build static library (for lz4-c-static output to copy later)
+mkdir %SRC_DIR%\build_static
+cd %SRC_DIR%\build_static
 if errorlevel 1 exit 1
 
-:: This is a shorter version of `make lz4-test-basic`.
-datagen -g0     | lz4 -v     | lz4 -t
-if errorlevel 1 exit 1
-datagen -g16KB  | lz4 -9     | lz4 -t
-if errorlevel 1 exit 1
-datagen         | lz4        | lz4 -t
-if errorlevel 1 exit 1
-datagen -g6M -P99 | lz4 -9BD | lz4 -t
-if errorlevel 1 exit 1
-datagen -g17M   | lz4 -9v    | lz4 -qt
-if errorlevel 1 exit 1
-datagen -g33M   | lz4 --no-frame-crc | lz4 -t
-if errorlevel 1 exit 1
-datagen -g256MB | lz4 -vqB4D | lz4 -t
+cmake -G Ninja ^
+    %CMAKE_ARGS% ^
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+    -DLZ4_BUILD_CLI=OFF ^
+    -DLZ4_BUILD_LEGACY_LZ4C=OFF ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DBUILD_STATIC_LIBS=ON ^
+    %SRC_DIR%\build\cmake
 if errorlevel 1 exit 1
 
-:: Install.
-COPY %SRC_DIR%\lib\lz4.h %LIBRARY_INC%
-if errorlevel 1 exit 1
-COPY %SRC_DIR%\lib\lz4hc.h %LIBRARY_INC%
-if errorlevel 1 exit 1
-COPY %SRC_DIR%\lib\lz4frame.h %LIBRARY_INC%
-if errorlevel 1 exit 1
-COPY %BUILD_DIR%\liblz4.dll %LIBRARY_BIN%
-if errorlevel 1 exit 1
-COPY %BUILD_DIR%\liblz4.lib %LIBRARY_LIB%
-if errorlevel 1 exit 1
-COPY %BUILD_DIR%\lz4.exe %LIBRARY_BIN%
+cmake --build . --config Release --parallel %CPU_COUNT%
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,10 +13,20 @@ cmake -G Ninja ^
     -DLZ4_BUILD_LEGACY_LZ4C=OFF ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_STATIC_LIBS=OFF ^
+    -DCMAKE_SHARED_LIBRARY_PREFIX=lib ^
+    -DCMAKE_IMPORT_LIBRARY_PREFIX=lib ^
     %SRC_DIR%\build\cmake
 if errorlevel 1 exit 1
 
 cmake --build . --config Release --parallel %CPU_COUNT%
+if errorlevel 1 exit 1
+
+cl.exe /nologo /O2 ^
+    /I "%SRC_DIR%\lib" ^
+    /I "%SRC_DIR%\programs" ^
+    "%SRC_DIR%\programs\datagen.c" ^
+    "%SRC_DIR%\tests\datagencli.c" ^
+    /Fe:datagen.exe
 if errorlevel 1 exit 1
 
 :: Run tests only if not cross-compiling
@@ -25,6 +35,25 @@ if not "%CONDA_BUILD_CROSS_COMPILATION%"=="1" (
     lz4 -i1b lz4.exe
     if errorlevel 1 exit 1
     lz4 -i1b5 lz4.exe
+    if errorlevel 1 exit 1
+    lz4 -i1b10 lz4.exe
+    if errorlevel 1 exit 1
+    lz4 -i1b15 lz4.exe
+    if errorlevel 1 exit 1
+
+    datagen -g0     | lz4 -v     | lz4 -t
+    if errorlevel 1 exit 1
+    datagen -g16KB  | lz4 -9     | lz4 -t
+    if errorlevel 1 exit 1
+    datagen         | lz4        | lz4 -t
+    if errorlevel 1 exit 1
+    datagen -g6M -P99 | lz4 -9BD | lz4 -t
+    if errorlevel 1 exit 1
+    datagen -g17M   | lz4 -9v    | lz4 -qt
+    if errorlevel 1 exit 1
+    datagen -g33M   | lz4 --no-frame-crc | lz4 -t
+    if errorlevel 1 exit 1
+    datagen -g256MB | lz4 -vqB4D | lz4 -t
     if errorlevel 1 exit 1
 )
 

--- a/recipe/bld_static.bat
+++ b/recipe/bld_static.bat
@@ -1,13 +1,4 @@
-:: Build
-if "%ARCH%"=="32" (
-    set PLATFORM=Win32
-) else (
-    set PLATFORM=x64
-)
-set CONFIGURATION=Release
-set VSPROJ_DIR=%SRC_DIR%\build\VS2017
-set BUILD_DIR=%VSPROJ_DIR%\bin\%PLATFORM%_%CONFIGURATION%
-
-COPY %BUILD_DIR%\liblz4_static.lib %LIBRARY_LIB%
+@echo off
+:: Copy the static library built during the main build phase
+COPY %SRC_DIR%\build_static\lz4.lib %LIBRARY_LIB%\lz4_static.lib
 if errorlevel 1 exit 1
-

--- a/recipe/bld_static.bat
+++ b/recipe/bld_static.bat
@@ -1,4 +1,4 @@
 @echo off
 :: Copy the static library built during the main build phase
-COPY %SRC_DIR%\build_static\lz4.lib %LIBRARY_LIB%\lz4_static.lib
+COPY "%SRC_DIR%\build_static\lz4.lib" "%LIBRARY_LIB%\liblz4_static.lib"
 if errorlevel 1 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+c_compiler:          # [osx]
+  - clang_bootstrap  # [osx]
+
+cxx_compiler:        # [osx]
+  - clang_bootstrap  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,22 +14,19 @@ source:
 build:
   number: 1
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}  # [not win]
-    - make  # [not win]
-    - cmake  # [win]
-    - ninja  # [win]
-  host:
-  run:
-
 outputs:
   - name: lz4-c
     build:
       # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
       run_exports:
         - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}  # [not win]
+        - make  # [not win]
+        - cmake  # [win]
+        - ninja  # [win]
     test:
       requires:
         - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}  # [not win]
     - make  # [not win]
-    - cmake  # [win]
-    - ninja  # [win]
+    ## Causes lz4-c to depend on itself?
+    # - cmake  # [win]
+    # - ninja  # [win]
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,19 +14,22 @@ source:
 build:
   number: 1
 
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}  # [not win]
+    - make  # [not win]
+    - cmake  # [win]
+    - ninja  # [win]
+  host:
+  run:
+
 outputs:
   - name: lz4-c
     build:
       # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
       run_exports:
         - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
-    requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}  # [not win]
-        - make  # [not win]
-        - cmake  # [win]
-        - ninja  # [win]
     test:
       requires:
         - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}  # [not win]
     - make  # [not win]
-    - m2-gcc-libs  # [win]
+    - cmake  # [win]
+    - ninja  # [win]
   host:
   run:
 
@@ -51,22 +52,20 @@ outputs:
         - test -f ${PREFIX}/lib/liblz4.dylib  # [osx]
         - test -f ${PREFIX}/lib/liblz4.so     # [linux]
 
-        - if not exist %LIBRARY_BIN%\\liblz4.dll exit 1         # [win]
-        - if not exist %LIBRARY_LIB%\\liblz4.lib exit 1         # [win]
-        - if exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\\lz4.dll exit 1         # [win]
+        - if not exist %LIBRARY_LIB%\\lz4.lib exit 1         # [win]
+        - if exist %LIBRARY_LIB%\\lz4_static.lib exit 1  # [win]
 
         - test -f ${PREFIX}/lib/pkgconfig/liblz4.pc  # [unix]
         - pkg-config --cflags --libs liblz4          # [unix]
 
   - name: lz4-c-static
-    build:
-      activate_in_script: true
     script: build_static.sh  # [unix]
     script: bld_static.bat  # [win]
     test:
       commands:
         - test -f ${PREFIX}/lib/liblz4.a      # [unix]
-        - if not exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\\lz4_static.lib exit 1  # [win]
 
 about:
   home: https://lz4.github.io/lz4/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
 
@@ -16,6 +15,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}  # [not win]
     - make  # [not win]
@@ -74,7 +74,7 @@ outputs:
         - if not exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
 
 about:
-  home: https://lz4.github.io/lz4/
+  home: https://lz4.org/
   license: BSD-2-Clause
   license_family: BSD
   license_file: lib/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,12 +52,18 @@ outputs:
         - test -f ${PREFIX}/lib/liblz4.dylib  # [osx]
         - test -f ${PREFIX}/lib/liblz4.so     # [linux]
 
-        - if not exist %LIBRARY_BIN%\\lz4.dll exit 1         # [win]
-        - if not exist %LIBRARY_LIB%\\lz4.lib exit 1         # [win]
-        - if exist %LIBRARY_LIB%\\lz4_static.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\\liblz4.dll exit 1         # [win]
+        - if not exist %LIBRARY_LIB%\\liblz4.lib exit 1         # [win]
+        - if exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
+        - if exist %LIBRARY_BIN%\\lz4.dll exit 1         # [win]
+        - if exist %LIBRARY_LIB%\\lz4.lib exit 1         # [win]
 
         - test -f ${PREFIX}/lib/pkgconfig/liblz4.pc  # [unix]
         - pkg-config --cflags --libs liblz4          # [unix]
+        - if not exist %LIBRARY_LIB%\\pkgconfig\\liblz4.pc exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\\cmake\\lz4\\lz4Targets.cmake exit 1  # [win]
+        - findstr /C:"liblz4.lib" "%LIBRARY_LIB%\\cmake\\lz4\\lz4Targets-release.cmake"  # [win]
+        - findstr /C:"liblz4.dll" "%LIBRARY_LIB%\\cmake\\lz4\\lz4Targets-release.cmake"  # [win]
 
   - name: lz4-c-static
     script: build_static.sh  # [unix]
@@ -65,7 +71,7 @@ outputs:
     test:
       commands:
         - test -f ${PREFIX}/lib/liblz4.a      # [unix]
-        - if not exist %LIBRARY_LIB%\\lz4_static.lib exit 1  # [win]
+        - if not exist %LIBRARY_LIB%\\liblz4_static.lib exit 1  # [win]
 
 about:
   home: https://lz4.github.io/lz4/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}  # [not win]
     - make  # [not win]
-    ## Causes lz4-c to depend on itself?
-    # - cmake  # [win]
-    # - ninja  # [win]
+    - cmake-no-system  # [win]
+    - ninja-base  # [win]
   host:
   run:
 


### PR DESCRIPTION
lz4-c win-arm64 support

**Destination channel:**  defaults

### Links

- [/PKG-15348](https://anaconda.atlassian.net/browse/PKG-15348) 

### Explanation of changes:

- Change so windows builds with cmake
   - Uses `cmake-no-system` to break cyclical dependencies.
   - Ensure filenames are same as before (By default cmake generates different names)
- Remove need for m2-gcc-libs on windows
- Maintain same tests. 
