### PR TITLE
Rename outer package so tests run.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,8 +13,6 @@ cmake -G Ninja ^
     -DLZ4_BUILD_LEGACY_LZ4C=OFF ^
     -DBUILD_SHARED_LIBS=ON ^
     -DBUILD_STATIC_LIBS=OFF ^
-    -DCMAKE_SHARED_LIBRARY_PREFIX=lib ^
-    -DCMAKE_IMPORT_LIBRARY_PREFIX=lib ^
     %SRC_DIR%\build\cmake
 if errorlevel 1 exit 1
 
@@ -60,6 +58,23 @@ if not "%CONDA_BUILD_CROSS_COMPILATION%"=="1" (
 :: Install shared library
 cmake --install . --config Release
 if errorlevel 1 exit 1
+
+:: Upstream CMake sets OUTPUT_NAME to "lz4" (see build/cmake/CMakeLists.txt).
+:: Conda defaults expect liblz4.dll / liblz4.lib for ABI compatibility.
+if exist "%LIBRARY_BIN%\lz4.dll" (
+    move /Y "%LIBRARY_BIN%\lz4.dll" "%LIBRARY_BIN%\liblz4.dll"
+    if errorlevel 1 exit 1
+)
+if exist "%LIBRARY_LIB%\lz4.lib" (
+    move /Y "%LIBRARY_LIB%\lz4.lib" "%LIBRARY_LIB%\liblz4.lib"
+    if errorlevel 1 exit 1
+)
+set "_lz4_cmake_targets=%LIBRARY_LIB%\cmake\lz4\lz4Targets-release.cmake"
+if exist "%_lz4_cmake_targets%" (
+    powershell -NoProfile -Command ^
+        "(Get-Content -LiteralPath '%_lz4_cmake_targets%') -replace 'lz4\.lib\"', 'liblz4.lib\"' -replace 'lz4\.dll\"', 'liblz4.dll\"' | Set-Content -LiteralPath '%_lz4_cmake_targets%' -Encoding utf8"
+    if errorlevel 1 exit 1
+)
 
 :: Also build static library (for lz4-c-static output to copy later)
 mkdir %SRC_DIR%\build_static

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ outputs:
         - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}  # [not win]
         - make  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -34,17 +34,18 @@ outputs:
     # Required when package.name != output name: conda-build only auto-fills
     # files for the output whose name matches the top-level package.
     files:
-      include:
-        - bin/**            # [unix]
-        - include/**        # [unix]
-        - lib/**            # [unix]
-        - Library/bin/**    # [win]
-        - Library/include/**  # [win]
-        - Library/lib/**    # [win]
-        - Library/share/**  # [win]
-      exclude:
-        - lib/liblz4.a                    # [unix]
-        - Library/lib/liblz4_static.lib   # [win]
+      - bin/**                          # [unix]
+      - include/**                      # [unix]
+      - lib/liblz4*{{ SHLIB_EXT }}*     # [unix]
+      - lib/pkgconfig/**                # [unix]
+      - share/man/man1/**               # [unix]
+      - Library/bin/liblz4.dll          # [win]
+      - Library/bin/lz4.exe             # [win]
+      - Library/include/**              # [win]
+      - Library/lib/liblz4.lib          # [win]
+      - Library/lib/pkgconfig/**        # [win]
+      - Library/lib/cmake/lz4/**        # [win]
+      - Library/share/man/**            # [win]
     test:
       requires:
         - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,10 @@
 {% set pkg_name = "lz4-c" %}
+{% set recipe_name = "lz4-c-split" %}
 {% set name = "lz4" %}
 {% set version = "1.9.4" %}
 
 package:
-  name: {{ pkg_name }}
+  name: {{ recipe_name }}
   version: {{ version }}
 
 source:
@@ -11,7 +12,7 @@ source:
   sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,20 @@ outputs:
       # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
       run_exports:
         - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
+    # Required when package.name != output name: conda-build only auto-fills
+    # files for the output whose name matches the top-level package.
+    files:
+      include:
+        - bin/**            # [unix]
+        - include/**        # [unix]
+        - lib/**            # [unix]
+        - Library/bin/**    # [win]
+        - Library/include/**  # [win]
+        - Library/lib/**    # [win]
+        - Library/share/**  # [win]
+      exclude:
+        - lib/liblz4.a                    # [unix]
+        - Library/lib/liblz4_static.lib   # [win]
     test:
       requires:
         - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b
 
 build:
-  number: 4
+  number: 3
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,9 @@
 {% set pkg_name = "lz4-c" %}
-{% set recipe_name = "lz4-c-split" %}
 {% set name = "lz4" %}
 {% set version = "1.9.4" %}
 
 package:
-  name: {{ recipe_name }}
+  name: {{ pkg_name }}-split
   version: {{ version }}
 
 source:
@@ -39,8 +38,11 @@ outputs:
         - make  # [not win]
         - cmake-no-system  # [win]
         - ninja-base  # [win]
-    # Required when package.name != output name: conda-build only auto-fills
-    # files for the output whose name matches the top-level package.
+    # Multi-output recipes disable conda-build's default "bundle everything in
+    # PREFIX" behavior; each output needs explicit files: and/or a per-output
+    # script.  Here, recipe-level bld.bat/build.sh install shared artifacts
+    # into PREFIX once before outputs run.  The lz4-c output has no script, so
+    # these globs are what populate the package.
     files:
       - bin/**                          # [unix]
       - include/**                      # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,13 @@ outputs:
       # https://abi-laboratory.pro/index.php?view=timeline&l=lz4
       run_exports:
         - {{ pin_subpackage(pkg_name, max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}  # [not win]
+        - make  # [not win]
+        - cmake-no-system  # [win]
+        - ninja-base  # [win]
     # Required when package.name != output name: conda-build only auto-fills
     # files for the output whose name matches the top-level package.
     files:


### PR DESCRIPTION
lz4-c 1.9.4 rebuild (fix Windows ABI + restore multi-output tests)

**Destination channel:** defaults

### Links
- [PKG-15348](https://anaconda.atlassian.net/browse/PKG-15348)
- [Upstream repository](https://github.com/lz4/lz4)
- [Upstream v1.9.4](https://github.com/lz4/lz4/releases/tag/v1.9.4)
- Follow-up to [#7](https://github.com/AnacondaRecipes/lz4-c-feedstock/pull/7) (merged 2026-06-12)
### Explanation of changes
Hotfix rebuild (build number 2 → 3) for a **Windows packaging ABI regression** introduced in #7 when Windows was migrated from MSBuild to CMake for win-arm64 support.
#### Background: what #7 broke
#7 switched Windows to CMake/Ninja (`cmake-no-system`) and attempted to preserve the historical `liblz4.dll` / `liblz4.lib` names via `-DCMAKE_SHARED_LIBRARY_PREFIX=lib`. That does not work because upstream CMake sets `OUTPUT_NAME lz4` ([build/cmake/CMakeLists.txt](https://github.com/lz4/lz4/blob/v1.9.4/build/cmake/CMakeLists.txt)), so `cmake --install` places `lz4.dll` and `lz4.lib` — breaking downstream consumers that link against `liblz4.lib` and load `liblz4.dll` (the pkgs/main contract since the MSBuild era).
This is a **link/load-name ABI** issue, not a C API/symbol change: upstream remains 1.9.4.
#7 also added regression tests (`if exist lz4.dll exit 1`, CMake targets checks), but those tests did not run against the `lz4-c` output because `package.name` matched the `lz4-c` output name in a multi-output recipe — so the bad Windows builds were not caught in CI.
#### Fixes in this PR
1. **Restore Windows artifact names** (`recipe/bld.bat`):
   - Drop ineffective `CMAKE_SHARED_LIBRARY_PREFIX` / `CMAKE_IMPORT_LIBRARY_PREFIX`
   - Post-install rename: `lz4.dll` → `liblz4.dll`, `lz4.lib` → `liblz4.lib`
   - Patch `Library/lib/cmake/lz4/lz4Targets-release.cmake` so `LZ4::lz4_shared` references `liblz4.*`
2. **Make `lz4-c` tests actually run** (`recipe/meta.yaml`):
   - Rename outer `package.name` to `lz4-c-split` (outputs remain `lz4-c` / `lz4-c-static`)
   - Add explicit `files:` globs on the `lz4-c` output (required when outer name ≠ output name)
   - Duplicate `requirements/build` on the `lz4-c` output for correct split-output compilation
3. **Unix platforms unchanged** — still built with `make`; `liblz4.so` / `liblz4.dylib` layout preserved.
#### ABI compatibility verification
| Check | linux / osx | win-64 (this graph) |
|---|---|---|
| Shared lib name | `liblz4.so` / `liblz4.dylib` | `liblz4.dll` (not `lz4.dll`) |
| Import lib | N/A | `liblz4.lib` (not `lz4.lib`) |
| No static lib in shared output | ✓ | ✓ |
| pkg-config | `liblz4.pc` | `liblz4.pc` |
| CMake config | N/A (unix) | `lz4Targets-release.cmake` references `liblz4.*` |
| CLI smoke tests | `lz4 -h`, compression round-trips | same |
**Windows artifact diff (build 2 → build 3):**
| | build 2 (#7, master) | build 3 (this PR) |
|---|---|---|
| Path count (win-64) | 6 | 12 |
| `Library/bin/liblz4.dll` | ✗ (was `lz4.dll`) | ✓ |
| `Library/lib/liblz4.lib` | ✗ (was `lz4.lib`) | ✓ |
| `Library/lib/cmake/lz4/*` | present but wrong target paths | present, patched |
| `Library/lib/pkgconfig/liblz4.pc` | new in #7 | ✓ |
| `Library/share/man/man1/lz4.1` | new in #7 | ✓ |


[PKG-15348]: https://anaconda.atlassian.net/browse/PKG-15348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ